### PR TITLE
Reset controls when the game ends

### DIFF
--- a/src/controls.js
+++ b/src/controls.js
@@ -114,3 +114,7 @@ export function updateControls(ship1, ship2) {
     }
 
 }
+
+export function resetControls() {
+    Object.keys(keysDown).forEach(v => keysDown[v] = false)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -77,6 +77,7 @@ var isRestarted = false;
 
 const restartGame = () => {
 	isRestarted = true;
+	controls.resetControls();
 	ship1.restart();
 	ship2.restart();
 	Bullet.destroyAllBullets();


### PR DESCRIPTION
Currently, when the game ends, the controls are not reset. This makes it so that whenever a new game start, the ships start to accelerate without any key press.

This PR addresses this issue by setting the values of the `keysDown` object to false every time the game ends.